### PR TITLE
The patch fixes the following error

### DIFF
--- a/pykg_config/result.py
+++ b/pykg_config/result.py
@@ -73,8 +73,14 @@ class NoPackagesSpecifiedError(PykgConfigError):
 # Private utility functions
 
 def _filter_duplicates(source):
-    # This doesn't maintain order.
-    return [val for val in source if val not in locals()['_[1]']]
+    # This maintains the order.
+    ret = []
+    seen = { }
+    for it in source:
+         if it not in seen:
+              ret.append(it)
+              seen[it] = 1
+    return ret
 
 ##############################################################################
 # PkgCfgResult object


### PR DESCRIPTION
$ PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig ./pykg-config --libs glib-2.0
Traceback (most recent call last):
  File "./pykg-config.py", line 377, in <module>
    main(sys.argv)
  File "./pykg-config.py", line 369, in main
    print result.get_all_lib_flags()
  File "/home/varg/pykg-config/pykg_config/result.py", line 181, in get_all_lib_flags
    return self._format_list(_filter_duplicates(result))
  File "/home/varg/pykg-config/pykg_config/result.py", line 77, in _filter_duplicates
    return [val for val in source if val not in locals()['_[1]']]
KeyError: '_[1]'
