### PR TITLE
Fix substitude regex replacement

### DIFF
--- a/pykg_config/substitute.py
+++ b/pykg_config/substitute.py
@@ -105,6 +105,8 @@ def substitute(value, replacements, globals={}):
 def replace_in_string(value, name, substitution):
     # Replace all instances of name in value with substitution
     to_replace = get_to_replace_re(name)
+    # Make sure backslashes are escaped (e.g. '\g' or '\0', ... are escaped)
+    substitution = substitution.replace('\\', '\\\\')
     return to_replace.sub(substitution, value)
 
 


### PR DESCRIPTION
The python re.sub function supports backslash escapes (like \6 or \g<2>). 
Therefore every backslash in replace_in_string function needs to be escaped. 
Note: This only happens on Windows due to its path separator.