### PR TITLE
Some more packaging imporvements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
+setup_requires = setuptools>=30.3.0; wheel; setuptools_scm
 packages = pykg_config
 
 [options.entry_points]


### PR DESCRIPTION
Added setup_requires into setup.cfg. Needed to automatically install setuptools_scm by old versions of setuptools.
Added pyproject.toml. Also can install the deps (but needs a newer version of setuptools) and allows to build the package with `build` tool.